### PR TITLE
Feature/diary

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Swagger/OpenAPI 문서화 -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/example/backend/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/backend/controller/DiaryController.java
@@ -1,0 +1,72 @@
+package com.example.backend.controller;
+
+import com.example.backend.entity.Diary;
+import com.example.backend.service.DiaryService;
+import com.example.backend.dto.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+public class DiaryController {
+    @Autowired
+    private DiaryService diaryService;
+
+    // ===================== REST API =====================
+
+    // 일기 저장 (REST)
+    @PostMapping("/api/diaries")
+    @ResponseBody
+    public ResponseEntity<ApiResponse<Diary>> saveDiary(@RequestParam Long userId,
+                                           @RequestParam String content,
+                                           @RequestParam String appliedStamp) {
+        Diary saved = diaryService.saveDiary(userId, content, appliedStamp);
+        return ResponseEntity.ok(new ApiResponse<>(true, "일기 저장 성공", saved));
+    }
+
+    // 유저별, 월별 일기 목록 조회 (REST)
+    @GetMapping("/api/diaries")
+    @ResponseBody
+    public ResponseEntity<ApiResponse<List<Diary>>> getDiariesByUserAndMonth(@RequestParam Long userId,
+                                                                @RequestParam int year,
+                                                                @RequestParam int month) {
+        List<Diary> diaries = diaryService.getDiariesByUserAndMonth(userId, year, month);
+        return ResponseEntity.ok(new ApiResponse<>(true, "일기 목록 조회 성공", diaries));
+    }
+
+    // 일기 상세 조회 (REST)
+    @GetMapping("/api/diaries/{id}")
+    @ResponseBody
+    public ResponseEntity<ApiResponse<Diary>> getDiaryById(@PathVariable Long id) {
+        Optional<Diary> diary = diaryService.getDiaryById(id);
+        if (diary.isPresent()) {
+            return ResponseEntity.ok(new ApiResponse<>(true, "일기 조회 성공", diary.get()));
+        } else {
+            return ResponseEntity.ok(new ApiResponse<>(false, "일기를 찾을 수 없습니다", null));
+        }
+    }
+
+    // ===================== Thymeleaf =====================
+
+    // 달력/일기 페이지 렌더링 (Thymeleaf)
+    @GetMapping("/diary-calendar")
+    public String diaryCalendarPage(Model model) {
+        // 필요시 model에 데이터 추가
+        return "diary_calendar";
+    }
+
+    // (옵션) 폼 기반 일기 저장 (Thymeleaf)
+    @PostMapping("/diary")
+    public String saveDiaryForm(@RequestParam Long userId,
+                                @RequestParam String content,
+                                @RequestParam String appliedStamp,
+                                Model model) {
+        diaryService.saveDiary(userId, content, appliedStamp);
+        return "redirect:/diary-calendar";
+    }
+} 

--- a/backend/src/main/java/com/example/backend/controller/HomeController.java
+++ b/backend/src/main/java/com/example/backend/controller/HomeController.java
@@ -34,9 +34,4 @@ public class HomeController {
         testService.saveTestMessage(message);
         return "redirect:/";
     }
-
-    @GetMapping("/diary-calendar")
-    public String diaryCalendar() {
-        return "diary_calendar";
-    }
 } 

--- a/backend/src/main/java/com/example/backend/controller/HomeController.java
+++ b/backend/src/main/java/com/example/backend/controller/HomeController.java
@@ -34,4 +34,9 @@ public class HomeController {
         testService.saveTestMessage(message);
         return "redirect:/";
     }
+
+    @GetMapping("/diary-calendar")
+    public String diaryCalendar() {
+        return "diary_calendar";
+    }
 } 

--- a/backend/src/main/java/com/example/backend/dto/ApiResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.example.backend.dto;
+
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    public ApiResponse() {}
+    public ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+    public boolean isSuccess() { return success; }
+    public void setSuccess(boolean success) { this.success = success; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public T getData() { return data; }
+    public void setData(T data) { this.data = data; }
+} 

--- a/backend/src/main/java/com/example/backend/entity/Diary.java
+++ b/backend/src/main/java/com/example/backend/entity/Diary.java
@@ -1,0 +1,37 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "diary")
+public class Diary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long diaryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, length = 50)
+    private String appliedStamp;
+
+    // getter/setter
+    public Long getDiaryId() { return diaryId; }
+    public void setDiaryId(Long diaryId) { this.diaryId = diaryId; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public String getAppliedStamp() { return appliedStamp; }
+    public void setAppliedStamp(String appliedStamp) { this.appliedStamp = appliedStamp; }
+} 

--- a/backend/src/main/java/com/example/backend/entity/Stamp.java
+++ b/backend/src/main/java/com/example/backend/entity/Stamp.java
@@ -1,0 +1,55 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stamp")
+public class Stamp {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long stampId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String image;
+
+    @Column(length = 255)
+    private String qualification;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, length = 50)
+    private String status;
+
+    @Column(nullable = false)
+    private LocalDateTime salesAt;
+
+    private LocalDateTime salesEnd;
+
+    // getter/setter
+    public Long getStampId() { return stampId; }
+    public void setStampId(Long stampId) { this.stampId = stampId; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getImage() { return image; }
+    public void setImage(String image) { this.image = image; }
+    public String getQualification() { return qualification; }
+    public void setQualification(String qualification) { this.qualification = qualification; }
+    public int getPrice() { return price; }
+    public void setPrice(int price) { this.price = price; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public java.time.LocalDateTime getSalesAt() { return salesAt; }
+    public void setSalesAt(java.time.LocalDateTime salesAt) { this.salesAt = salesAt; }
+    public java.time.LocalDateTime getSalesEnd() { return salesEnd; }
+    public void setSalesEnd(java.time.LocalDateTime salesEnd) { this.salesEnd = salesEnd; }
+} 

--- a/backend/src/main/java/com/example/backend/entity/User.java
+++ b/backend/src/main/java/com/example/backend/entity/User.java
@@ -1,0 +1,75 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId; // Primary Key
+
+    @Column(nullable = false, length = 255)
+    private String userEmail; // 이메일 주소
+
+    @Column(nullable = false, length = 255)
+    private String userPassword; // 해시된 비밀번호
+
+    @Column(nullable = false, length = 50)
+    private String userNickname; // 사용자 표시 이름
+
+    @Column(nullable = false, length = 20)
+    private String userPhone; // 미포함
+
+    @Column(nullable = false)
+    private int userFailedLogin = 0; // 로그인 실패 누적 횟수
+
+    @Column(nullable = false)
+    private LocalDateTime userLastLogin = LocalDateTime.now(); // 마지막 로그인 시간
+
+    @Column(nullable = false)
+    private int userCommentTime = 6; // AI 코멘트 받을 시간
+
+    @Column(nullable = false)
+    private int userTokenCount = 0; // 잔여 토큰 수
+
+    @Column(nullable = false)
+    private LocalDateTime userCreatedAt = LocalDateTime.now(); // 가입일
+
+    @Column(nullable = false, length = 20)
+    private String userStatus = "active"; // 상태 코드
+
+    private LocalDateTime userDeletedAt; // 탈퇴한 시점 (NULL이면 활성 회원)
+
+    @Column(length = 100)
+    private String userKakaoId; // 카카오 연동용 사용자 식별자
+
+    // getter/setter
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public String getUserEmail() { return userEmail; }
+    public void setUserEmail(String userEmail) { this.userEmail = userEmail; }
+    public String getUserPassword() { return userPassword; }
+    public void setUserPassword(String userPassword) { this.userPassword = userPassword; }
+    public String getUserNickname() { return userNickname; }
+    public void setUserNickname(String userNickname) { this.userNickname = userNickname; }
+    public String getUserPhone() { return userPhone; }
+    public void setUserPhone(String userPhone) { this.userPhone = userPhone; }
+    public int getUserFailedLogin() { return userFailedLogin; }
+    public void setUserFailedLogin(int userFailedLogin) { this.userFailedLogin = userFailedLogin; }
+    public LocalDateTime getUserLastLogin() { return userLastLogin; }
+    public void setUserLastLogin(LocalDateTime userLastLogin) { this.userLastLogin = userLastLogin; }
+    public int getUserCommentTime() { return userCommentTime; }
+    public void setUserCommentTime(int userCommentTime) { this.userCommentTime = userCommentTime; }
+    public int getUserTokenCount() { return userTokenCount; }
+    public void setUserTokenCount(int userTokenCount) { this.userTokenCount = userTokenCount; }
+    public LocalDateTime getUserCreatedAt() { return userCreatedAt; }
+    public void setUserCreatedAt(LocalDateTime userCreatedAt) { this.userCreatedAt = userCreatedAt; }
+    public String getUserStatus() { return userStatus; }
+    public void setUserStatus(String userStatus) { this.userStatus = userStatus; }
+    public LocalDateTime getUserDeletedAt() { return userDeletedAt; }
+    public void setUserDeletedAt(LocalDateTime userDeletedAt) { this.userDeletedAt = userDeletedAt; }
+    public String getUserKakaoId() { return userKakaoId; }
+    public void setUserKakaoId(String userKakaoId) { this.userKakaoId = userKakaoId; }
+} 

--- a/backend/src/main/java/com/example/backend/repository/DiaryRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/DiaryRepository.java
@@ -1,0 +1,14 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Diary;
+import com.example.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
+} 

--- a/backend/src/main/java/com/example/backend/repository/StampRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/StampRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Stamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+} 

--- a/backend/src/main/java/com/example/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+} 

--- a/backend/src/main/java/com/example/backend/service/DiaryService.java
+++ b/backend/src/main/java/com/example/backend/service/DiaryService.java
@@ -1,0 +1,48 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Diary;
+import com.example.backend.entity.User;
+import com.example.backend.repository.DiaryRepository;
+import com.example.backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DiaryService {
+    @Autowired
+    private DiaryRepository diaryRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    // 일기 저장
+    public Diary saveDiary(Long userId, String content, String appliedStamp) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Diary diary = new Diary();
+        diary.setUser(user);
+        diary.setCreatedAt(LocalDateTime.now());
+        diary.setContent(content);
+        diary.setAppliedStamp(appliedStamp);
+        return diaryRepository.save(diary);
+    }
+
+    // 유저별, 월별 일기 목록 조회
+    public List<Diary> getDiariesByUserAndMonth(Long userId, int year, int month) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        LocalDate start = YearMonth.of(year, month).atDay(1);
+        LocalDate end = YearMonth.of(year, month).atEndOfMonth();
+        LocalDateTime startDateTime = start.atStartOfDay();
+        LocalDateTime endDateTime = end.atTime(23,59,59);
+        return diaryRepository.findByUserAndCreatedAtBetween(user, startDateTime, endDateTime);
+    }
+
+    // 일기 상세 조회
+    public Optional<Diary> getDiaryById(Long diaryId) {
+        return diaryRepository.findById(diaryId);
+    }
+} 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Database Configuration
 spring.datasource.url=jdbc:mysql://localhost:3306/rebuild_db?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=Choi3495!_!
+spring.datasource.username=nahcoh
+spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA Configuration

--- a/backend/src/main/resources/templates/diary_calendar.html
+++ b/backend/src/main/resources/templates/diary_calendar.html
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>인생, 쓰다 - 일기 기록 및 달력</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+    
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            background-color: #F4DDB8; /* WHEAT */
+            color: #495235; /* DARK FERN */
+        }
+        .container-card {
+            background-color: white;
+            border-radius: 1rem;
+            padding: 2rem;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+            border: 1px solid #B87B5C; /* BROWN SUGAR */
+        }
+        .section-title {
+            font-size: 1.75rem; /* text-3xl */
+            font-weight: 600; /* font-semibold */
+            color: #90533B; /* CHESTNUT */
+            margin-bottom: 1.5rem;
+            border-bottom: 1px solid #B87B5C; /* BROWN SUGAR */
+            padding-bottom: 0.5rem;
+        }
+        .info-item { /* 기존 CSS에서 사용된 info-item 스타일 유지 */
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 0;
+            border-bottom: 1px dashed #E0E0E0;
+        }
+        .info-item:last-child {
+            border-bottom: none;
+        }
+        .info-label {
+            font-weight: 500;
+            color: #495235;
+        }
+        .info-value {
+            color: #8F9562;
+            font-weight: 400;
+        }
+        /* Common button styles */
+        .btn-main {
+            background-color: #DA983C; /* HARVEST GOLD */
+            color: white;
+            padding: 1rem 2.5rem;
+            border-radius: 0.75rem;
+            font-weight: 600;
+            font-size: 1.25rem;
+            transition: background-color 0.3s ease-in-out, transform 0.2s ease-in-out;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
+        .btn-main:hover {
+            background-color: #90533B; /* CHESTNUT */
+            transform: translateY(-2px);
+        }
+        .btn-nav { /* for calendar nav */
+            background-color: #B87B5C;
+            color: white;
+            padding: 0.6rem 1.2rem;
+            border-radius: 0.6rem;
+            font-weight: 500;
+            transition: background-color 0.2s ease-in-out;
+        }
+        .btn-nav:hover {
+            background-color: #90533B;
+        }
+        /* New toggle button style */
+        .btn-toggle {
+            background-color: #8F9562; /* MOSS GREEN */
+            color: white;
+            padding: 0.75rem 1.25rem;
+            border-radius: 0.5rem;
+            font-weight: 500;
+            transition: background-color 0.2s ease-in-out;
+            white-space: nowrap; /* 텍스트 줄바꿈 방지 */
+        }
+        .btn-toggle:hover {
+            background-color: #495235; /* DARK FERN */
+        }
+        /* AI Chat button moved to action area */
+        .btn-ai-chat-action {
+            background-color: #8F9562; /* MOSS GREEN */
+            color: white;
+            padding: 1rem 2.5rem;
+            border-radius: 0.75rem;
+            font-weight: 600;
+            font-size: 1.25rem;
+            transition: background-color 0.2s ease-in-out;
+            width: 100%; /* 너비를 꽉 채우도록 */
+        }
+        .btn-ai-chat-action:hover {
+            background-color: #495235; /* DARK FERN */
+        }
+
+        /* Input field style */
+        .input-field {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border: 1px solid #B87B5C;
+            border-radius: 0.5rem;
+            font-size: 1rem;
+            color: #495235;
+            background-color: white;
+        }
+        .input-field:focus {
+            outline: none;
+            border-color: #DA983C;
+            box-shadow: 0 0 0 2px rgba(218, 152, 60, 0.2);
+        }
+
+        /* AI Comment Box */
+        .ai-comment-box {
+            background-color: #F4DDB8;
+            border: 1px solid #8F9562;
+            border-radius: 1rem;
+            padding: 1.5rem;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            position: relative;
+            overflow: hidden;
+            display: flex; /* 내부 요소들을 flex로 정렬 */
+            flex-direction: column; /* 세로로 정렬 */
+            flex-shrink: 0; /* 이 요소는 줄어들지 않음 */
+        }
+        .stamp-image-comment {
+            position: absolute;
+            top: -15px;
+            right: -15px;
+            width: 90px;
+            height: 90px;
+            transform: rotate(15deg);
+            opacity: 0.8;
+        }
+        .record-item {
+            background-color: white;
+            border: 1px solid #B87B5C;
+            border-radius: 0.5rem;
+            padding: 0.75rem 1rem;
+            margin-bottom: 0.5rem;
+            font-size: 0.95rem;
+            color: #495235;
+        }
+
+        /* Calendar Styles */
+        .calendar-grid {
+            display: grid;
+            grid-template-columns: repeat(7, 1fr);
+            gap: 0.5rem;
+            height: 380px; /* 이 값은 달력 내용과 여백에 따라 조정될 수 있습니다. */
+            flex-shrink: 0; /* 부모 flex 컨테이너 내에서 줄어들지 않도록 함 */
+        }
+        .date-cell {
+            background-color: white;
+            border: 1px solid #B87B5C;
+            border-radius: 0.75rem;
+            padding: 0.75rem;
+            aspect-ratio: 1 / 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.9rem;
+            cursor: pointer;
+            transition: transform 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+            position: relative;
+            overflow: hidden;
+            color: #495235;
+        }
+        .date-cell:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+        }
+        .date-cell.has-diary {
+            background-color: #F4DDB8;
+            border-color: #8F9562;
+        }
+        .date-cell.today {
+            border: 2px solid #DA983C;
+            font-weight: bold;
+        }
+        .stamp-image-calendar {
+            position: absolute;
+            bottom: -5px;
+            right: -5px;
+            width: 40px;
+            height: 40px;
+            transform: rotate(10deg);
+            opacity: 0.8;
+        }
+        .emotion-icon {
+            font-size: 1.3rem;
+            margin-top: 0.3rem;
+            color: #90533B;
+        }
+        /* Left Section: Calendar container */
+        .left-section-container {
+            flex-grow: 1; 
+            min-height: 550px; 
+            height: 800px; /* 고정 높이 설정 (스크린샷 비율에 맞춰 조정) */
+            overflow-y: auto; /* 리포트 목록이 많아지면 스크롤되도록 */
+        }
+
+        /* Right Section container */
+        .right-section-container {
+            flex-grow: 1; /* 남은 공간을 채우도록 성장 */
+            min-height: 550px; /* 왼쪽과 비슷한 최소 높이 보장 */
+            height: 800px; /* 왼쪽과 동일하게 고정 높이 설정 */
+        }
+        /* 스크롤 가능한 기록 목록의 직접적인 부모를 지정 */
+        .records-list-wrapper {
+            max-height: 250px; /* 초기 높이 제한. 이 값은 디자인에 따라 조정하세요. */
+            overflow-y: auto; /* 내부의 기록들만 스크롤되도록 */
+            padding: 1rem; /* 상자처럼 패딩 추가 */
+            padding-bottom: 1.5rem; /* 하단 패딩을 더 늘림 */
+            border: 1px solid #B87B5C; /* 얇은 테두리 추가 */
+            border-radius: 0.5rem; /* 모서리 둥글게 */
+            margin-bottom: 1rem; /* 하단 여백 추가 */
+            flex-shrink: 0; /* 이 래퍼가 줄어들지 않도록 함 */
+            background-color: white; /* 배경색도 하얀색으로 통일 */
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05); /* 은은한 그림자 */
+        }
+        /* 오늘의 명언 블록 스타일 */
+        .daily-quote-box {
+            background-color: #F4DDB8; /* WHEAT */
+            border: 1px dashed #DA983C; /* HARVEST GOLD */
+            border-radius: 0.75rem;
+            padding: 1rem 1.5rem;
+            margin-bottom: 1.5rem; /* 새로운 기록 남기기 섹션과의 간격 */
+            text-align: center;
+            font-style: italic;
+            color: #90533B; /* CHESTNUT */
+            line-height: 1.5;
+            font-size: 1.1rem;
+        }
+    </style>
+</head>
+<body class="min-h-screen flex flex-col items-center py-10 px-4 sm:px-6 lg:px-8">
+    <header class="w-full max-w-4xl text-center mb-10">
+        <h1 class="text-5xl font-bold text-[#90533B] mb-2">인생, 쓰다</h1>
+        <p class="text-2xl text-[#495235]">일기 기록 및 달력</p>
+    </header>
+
+    <section id="diary-calendar-page-section" class="w-full max-w-5xl flex flex-col lg:flex-row gap-8 py-10">
+        <div class="lg:w-1/2 container-card flex flex-col left-section-container">
+            <div class="flex justify-between items-center mb-6 flex-shrink-0"> <button class="btn-nav">&lt; 이전 달</button>
+                <h2 class="text-3xl font-semibold text-[#90533B]">2025년 7월</h2>
+                <button class="btn-nav">다음 달 &gt;</button>
+            </div>
+
+            <div class="calendar-grid mb-4"> <div class="text-center font-medium text-[#B87B5C]">일</div>
+                <div class="text-center font-medium text-[#495235]">월</div>
+                <div class="text-center font-medium text-[#495235]">화</div>
+                <div class="text-center font-medium text-[#495235]">수</div>
+                <div class="text-center font-medium text-[#495235]">목</div>
+                <div class="text-center font-medium text-[#495235]">금</div>
+                <div class="text-center font-medium text-[#B87B5C]">토</div>
+
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+                <div class="date-cell bg-gray-100 cursor-default border-none shadow-none"></div>
+
+                <div class="date-cell">1</div>
+                <div class="date-cell">2</div>
+                <div class="date-cell">3</div>
+                <div class="date-cell">4</div>
+                <div class="date-cell">5</div>
+                <div class="date-cell">6</div>
+                <div class="date-cell">7</div>
+                <div class="date-cell">8</div>
+                <div class="date-cell">9</div>
+                <div class="date-cell has-diary">
+                    10
+                    <img src="참잘했어요.jpg" alt="참 잘했어요 스탬프" class="stamp-image-calendar">
+                    <span class="emotion-icon">😊</span>
+                </div>
+                <div class="date-cell has-diary">
+                    11
+                    <img src="참잘했어요.jpg" alt="참 잘했어요 스탬프" class="stamp-image-calendar">
+                    <span class="emotion-icon">😅</span>
+                </div>
+                <div class="date-cell">12</div>
+                <div class="date-cell">13</div>
+                <div class="date-cell">14</div>
+                <div class="date-cell has-diary">
+                    15
+                    <img src="참잘했어요.jpg" alt="참 잘했어요 스탬프" class="stamp-image-calendar">
+                    <span class="emotion-icon">😔</span>
+                </div>
+                <div class="date-cell today has-diary">
+                    16
+                    <img src="참잘했어요.jpg" alt="참 잘했어요 스탬프" class="stamp-image-calendar">
+                    <span class="emotion-icon">😌</span>
+                </div>
+                <div class="date-cell">17</div>
+                <div class="date-cell">18</div>
+                <div class="date-cell">19</div>
+                <div class="date-cell">20</div>
+                <div class="date-cell">21</div>
+                <div class="date-cell">22</div>
+                <div class="date-cell">23</div>
+                <div class="date-cell">24</div>
+                <div class="date-cell">25</div>
+                <div class="date-cell">26</div>
+                <div class="date-cell">27</div>
+                <div class="date-cell">28</div>
+                <div class="date-cell">29</div>
+                <div class="date-cell">30</div>
+                <div class="date-cell">31</div>
+            </div>
+            <div class="text-center text-base text-[#8F9562] mt-4 flex-shrink-0"> <p>이번 달 일기: 15일 작성 | 연속 기록: 7일</p>
+                <p>주요 감정: 평온, 기쁨, 피로</p>
+            </div>
+
+            <div class="mt-8 flex-grow overflow-y-auto"> <h3 class="text-xl font-semibold text-[#90533B] mb-4">주차별 감정 리포트</h3>
+                <div id="weekly-reports-list" class="space-y-3">
+                    <div class="flex items-center justify-between bg-white p-4 rounded-lg border border-[#B87B5C]">
+                        <span class="text-[#495235] font-medium">7월 1주차 리포트 (7/1 ~ 7/7)</span>
+                        <button class="btn-nav bg-[#8F9562] hover:bg-[#495235] text-sm" onclick="alert('7월 1주차 리포트 페이지로 이동합니다!')">리포트 보기</button>
+                    </div>
+                    <div class="flex items-center justify-between bg-white p-4 rounded-lg border border-[#B87B5C]">
+                        <span class="text-[#495235] font-medium">7월 2주차 리포트 (7/8 ~ 7/14)</span>
+                        <button class="btn-nav bg-[#8F9562] hover:bg-[#495235] text-sm" onclick="alert('7월 2주차 리포트 페이지로 이동합니다!')">리포트 보기</button>
+                    </div>
+                    <div class="flex items-center justify-between bg-white p-4 rounded-lg border border-[#B87B5C] opacity-70">
+                        <span class="text-[#8F9562] font-medium">7월 3주차 리포트 (7/15 ~ 7/21)</span>
+                        <span class="text-[#B87B5C] text-sm">아직 준비 중</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="lg:w-1/2 container-card flex flex-col right-section-container"> 
+            <div class="mb-4 flex-shrink-0"> <h2 class="block text-xl font-semibold text-[#90533B] mb-3">오늘의 짧은 기록들</h2>
+                <div class="records-list-wrapper"> <div id="today-records-list-scrollable" class="space-y-2"> <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[10:30]</span>
+                            오늘 아침 햇살이 너무 좋아서 기분 좋게 일어났어요.
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[14:15]</span>
+                            점심으로 맛있는 파스타를 먹었는데, 정말 행복했어요!
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[16:00]</span>
+                            오후에는 친구와 카페에서 수다를 떨었는데, 즐거웠어요!
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[18:30]</span>
+                            저녁으로 간단하게 샐러드를 먹었어요. 건강한 느낌!
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[20:00]</span>
+                            좋아하는 드라마를 보면서 하루를 마무리하는 중입니다.
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[21:00]</span>
+                            새로운 책을 읽기 시작했는데, 내용이 정말 흥미로워요!
+                        </div>
+                        <div class="record-item">
+                            <span class="text-[#8F9562] text-sm mr-2">[22:30]</span>
+                            내일 일정을 정리하며 잠자리에 들 준비를 합니다.
+                        </div>
+                        <p id="no-records-placeholder" class="text-[#8F9562] text-center py-4 hidden">아직 오늘의 기록이 없어요. 첫 기록을 남겨보세요!</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="daily-quote-box mb-8 flex-shrink-0">
+                <p id="daily-quote-text">"당신의 작은 노력이 모여 큰 변화를 만듭니다."</p>
+                <p class="text-sm mt-2">- 알 수 없는 작가 -</p>
+            </div>
+
+            <div id="ai-comment-section" class="ai-comment-box mb-8 flex-shrink-0 hidden"> <img src="참잘했어요.jpg" alt="참 잘했어요 스탬프" class="stamp-image-comment">
+                <h3 class="text-2xl font-semibold text-[#90533B] mb-4">선생님의 따뜻한 코멘트</h3>
+                <p id="ai-comment-text" class="text-[#495235] leading-relaxed text-lg">
+                    사랑하는 제자님, 오늘 남겨주신 소중한 기록들을 읽었어요.
+                    작은 순간들이 모여 제자님의 하루를 아름답게 채우고 있네요.
+                    오늘의 기록을 통해 [감정 키워드 예시: 기쁨, 평온]이 느껴집니다.
+                    꾸준히 자신을 돌아보는 모습이 참 대견해요.
+                </p>
+                </div>
+
+            <div id="new-record-section" class="mt-auto flex-shrink-0"> <label for="diary-content" class="block text-xl font-semibold text-[#90533B] mb-3">새로운 기록 남기기</label>
+                <textarea id="diary-content" rows="4" class="w-full input-field resize-y" placeholder="지금 당신의 생각이나 감정을 한두 줄로 자유롭게 기록해주세요."></textarea>
+            </div>
+            
+            <div class="flex flex-col gap-4 mt-6 flex-shrink-0"> <button id="ai-chat-button" class="btn-ai-chat-action hidden"> AI와 채팅하기
+                </button>
+                <div class="flex justify-center items-center gap-4"> <button id="save-diary-btn" class="btn-main flex-grow"> 생각 기록하기
+                    </button>
+                    <button id="toggle-comment-record-btn" class="btn-toggle">
+                        코멘트 보기 (테스트용)
+                    </button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <script>
+        // --- Combined Diary/Calendar Page Scripts ---
+        const aiCommentSection = document.getElementById('ai-comment-section');
+        const newRecordSection = document.getElementById('new-record-section');
+        const toggleCommentRecordBtn = document.getElementById('toggle-comment-record-btn');
+        const recordsListScrollable = document.getElementById('today-records-list-scrollable');
+        const noRecordsPlaceholder = document.getElementById('no-records-placeholder');
+        const saveDiaryBtn = document.getElementById('save-diary-btn');
+        const diaryContent = document.getElementById('diary-content');
+        const aiChatButton = document.getElementById('ai-chat-button'); // AI 채팅 버튼
+        const dailyQuoteBox = document.querySelector('.daily-quote-box'); // 오늘의 명언 블록
+
+        // 초기 상태: 새로운 기록 남기기 섹션 보이고 코멘트 섹션 숨기기
+        let isRecordMode = true; // true: 기록 모드, false: 코멘트 모드
+
+        const dailyQuotes = [
+            "오늘의 작은 기록이 내일의 큰 변화를 만듭니다.",
+            "당신의 감정은 소중하며, 기록될 가치가 있습니다.",
+            "지나간 하루는 되돌릴 수 없지만, 기록은 영원합니다.",
+            "가장 어두운 밤에 가장 밝은 별이 빛난다."
+        ];
+        let currentDailyQuoteIndex = 0;
+
+        function updateDailyQuote() {
+            const quoteTextElement = document.getElementById('daily-quote-text');
+            if (quoteTextElement) {
+                quoteTextElement.innerText = dailyQuotes[currentDailyQuoteIndex];
+                currentDailyQuoteIndex = (currentDailyQuoteIndex + 1) % dailyQuotes.length;
+            }
+        }
+
+
+        function updateAIComment(allTodayRecords) {
+            const aiCommentText = document.getElementById('ai-comment-text');
+            const emotionKeywords = document.getElementById('emotion-keywords');
+            
+            if (allTodayRecords.length > 0) {
+                aiCommentText.innerText = `사랑하는 제자님, 오늘 남겨주신 소중한 기록들을 읽었어요.
+                작은 순간들이 모여 제자님의 하루를 아름답게 채우고 있네요.
+                오늘의 기록을 통해 [감정 키워드 예시: 기쁨, 평온]이 느껴집니다.
+                꾸준히 자신을 돌아보는 모습이 참 대견해요.`;
+                emotionKeywords.innerText = '오늘의 감정 키워드: #기쁨 #평온 #대견함 #일상';
+            } else {
+                aiCommentText.innerText = '아직 오늘의 기록이 없어서 선생님의 코멘트가 준비되지 않았어요. 첫 기록을 남겨보세요!';
+                emotionKeywords.innerText = '';
+            }
+        }
+
+        // 현재 모드에 따라 섹션 가시성 및 버튼 텍스트 업데이트
+        function updateSectionVisibility() {
+            if (isRecordMode) {
+                // 기록 모드: 새로운 기록 섹션 보이고, AI 코멘트 섹션 숨김
+                newRecordSection.classList.remove('hidden');
+                saveDiaryBtn.classList.remove('hidden');
+                dailyQuoteBox.classList.remove('hidden'); // 기록 모드일 때 명언 블록 표시
+                aiCommentSection.classList.add('hidden');
+                aiChatButton.classList.add('hidden'); // AI 채팅 버튼 숨김
+                toggleCommentRecordBtn.innerText = '코멘트 보기 (테스트용)';
+
+            } else {
+                // 코멘트 모드: AI 코멘트 섹션 보이고, 새로운 기록 섹션 숨김
+                newRecordSection.classList.add('hidden');
+                saveDiaryBtn.classList.add('hidden');
+                dailyQuoteBox.classList.add('hidden'); // 코멘트 모드일 때 명언 블록 숨김
+                aiCommentSection.classList.remove('hidden');
+                
+                // 코멘트가 있는 경우에만 AI 채팅 버튼 표시
+                const allRecords = Array.from(recordsListScrollable.children).filter(el => el.classList.contains('record-item') && el.id !== 'no-records-placeholder');
+                if (allRecords.length > 0) { // 예시 기록이 하나라도 있으면 AI 코멘트가 있다고 간주
+                    aiChatButton.classList.remove('hidden'); 
+                } else {
+                    aiChatButton.classList.add('hidden');
+                }
+                toggleCommentRecordBtn.innerText = '기록 남기기 (테스트용)';
+            }
+        }
+
+        // "생각 기록하기" 버튼 클릭 이벤트
+        saveDiaryBtn.addEventListener('click', function() {
+            const content = diaryContent.value.trim();
+            if (content) {
+                const now = new Date();
+                const time = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+                
+                const newRecordItem = document.createElement('div');
+                newRecordItem.className = 'record-item';
+                newRecordItem.innerHTML = `<span class="text-[#8F9562] text-sm mr-2">[${time}]</span>${content}`;
+                recordsListScrollable.prepend(newRecordItem); // Add to top of the list
+
+                diaryContent.value = ''; // Clear input
+                noRecordsPlaceholder.classList.add('hidden'); // Hide placeholder if visible
+
+                const allRecords = Array.from(recordsListScrollable.children).filter(el => el.classList.contains('record-item') && el.id !== 'no-records-placeholder');
+                updateAIComment(allRecords); // AI 코멘트 업데이트
+
+                recordsListScrollable.scrollTop = 0; // 스크롤을 최상단으로 이동
+                
+            } else {
+                alert('기록할 내용을 입력해주세요.');
+            }
+        });
+
+        // "코멘트/기록 전환" 버튼 클릭 이벤트
+        toggleCommentRecordBtn.addEventListener('click', function() {
+            isRecordMode = !isRecordMode; // 모드 토글
+            updateSectionVisibility(); // 가시성 업데이트
+            
+            // 코멘트 모드로 전환 시, AI 코멘트 내용 다시 계산
+            if (!isRecordMode) {
+                const allRecords = Array.from(recordsListScrollable.children).filter(el => el.classList.contains('record-item') && el.id !== 'no-records-placeholder');
+                updateAIComment(allRecords);
+            }
+        });
+
+        // "AI와 채팅하기" 버튼 클릭 이벤트
+        aiChatButton.addEventListener('click', function() {
+            alert('AI 채팅 페이지로 이동합니다!');
+            // 실제 구현 시 window.location.href = '/chat'; 등으로 페이지 이동
+        });
+
+
+        // 초기 로드 시 설정
+        document.addEventListener('DOMContentLoaded', function() {
+            // 초기 상태는 기록 모드로 시작하며, 코멘트 블록은 숨겨집니다.
+            isRecordMode = true; 
+            updateSectionVisibility();
+            updateDailyQuote(); // 초기 명언 설정
+            setInterval(updateDailyQuote, 10000); // 10초마다 명언 변경 (선택 사항)
+
+            // 초기 기록이 없는 경우 placeholder 표시
+            const initialRecords = Array.from(recordsListScrollable.children).filter(el => el.classList.contains('record-item') && el.id !== 'no-records-placeholder');
+            if (initialRecords.length === 0) {
+                noRecordsPlaceholder.classList.remove('hidden');
+            } else {
+                noRecordsPlaceholder.classList.add('hidden');
+            }
+            updateAIComment(initialRecords); // 초기 AI 코멘트 내용 설정 (숨겨져 있어도 내용 미리 준비)
+        });
+    </script>
+</body>
+</html>

--- a/backend/src/main/resources/templates/home.html
+++ b/backend/src/main/resources/templates/home.html
@@ -151,6 +151,7 @@
 <body>
     <div class="container">
         <h1>🚀 Rebuild Project</h1>
+        <a href="/diary-calendar" style="display:inline-block;margin-bottom:1.5rem;padding:0.75rem 2rem;background:#DA983C;color:white;border-radius:8px;font-weight:600;text-decoration:none;">일기 달력으로 이동</a>
         <div class="message" th:text="${message}">메시지</div>
         
         <div class="tech-stack">

--- a/backend/src/test/java/com/example/backend/entity/EntityIntegrationTest.java
+++ b/backend/src/test/java/com/example/backend/entity/EntityIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.example.backend.entity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.test.annotation.Rollback;
+
+import com.example.backend.repository.*;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Rollback(false) // 실제 DB 반영 확인용
+public class EntityIntegrationTest {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private DiaryRepository diaryRepository;
+    @Autowired
+    private StampRepository stampRepository;
+
+    @Test
+    void userEntitySaveAndFind() {
+        User user = new User();
+        user.setUserEmail("test2@example.com");
+        user.setUserPassword("pw");
+        user.setUserNickname("테스트2");
+        user.setUserPhone("010-0000-0000");
+        user.setUserStatus("active");
+        User saved = userRepository.save(user);
+        User found = userRepository.findById(saved.getUserId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getUserEmail()).isEqualTo("test2@example.com");
+    }
+
+    @Test
+    void stampEntitySaveAndFind() {
+        Stamp stamp = new Stamp();
+        stamp.setName("테스트스탬프");
+        stamp.setImage("/images/test.png");
+        stamp.setPrice(100);
+        stamp.setDescription("설명");
+        stamp.setStatus("판매중");
+        stamp.setSalesAt(LocalDateTime.now());
+        Stamp saved = stampRepository.save(stamp);
+        Stamp found = stampRepository.findById(saved.getStampId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("테스트스탬프");
+    }
+
+    @Test
+    void diaryEntitySaveAndFind() {
+        User user = userRepository.findAll().stream().findFirst().orElse(null);
+        assertThat(user).isNotNull();
+        Diary diary = new Diary();
+        diary.setUser(user);
+        diary.setCreatedAt(LocalDateTime.now());
+        diary.setContent("오늘의 일기");
+        diary.setAppliedStamp("기본 스탬프");
+        Diary saved = diaryRepository.save(diary);
+        Diary found = diaryRepository.findById(saved.getDiaryId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getContent()).isEqualTo("오늘의 일기");
+    }
+} 


### PR DESCRIPTION
✅ PR 개요
일기(다이어리) 서비스의 핵심 기능 및 API를 구현하고, Swagger를 통한 API 문서 자동화와 프론트 연동 예시를 제공합니다.
ERD 기반의 User, Diary, Stamp 엔티티 및 JPA Repository, Service, Controller(REST/Thymeleaf) 구조를 설계 및 구현했습니다.
🔗 관련 이슈
Resolved: # (관련 이슈 번호를 입력해 주세요)
📝 작업 내용
엔티티/리포지토리
User, Diary, Stamp 엔티티 생성 (ERD 기반)
각 엔티티별 JPA Repository 생성
서비스/비즈니스 로직
DiaryService: 일기 저장, 유저/월별 일기 목록 조회, 일기 상세 조회 기능 구현
컨트롤러
DiaryController: REST API(일기 저장/조회/상세) 및 Thymeleaf(달력/일기 페이지) 엔드포인트 구현
HomeController: 메인/테스트 페이지 라우팅, 중복 매핑 제거
API 응답 포맷
ApiResponse DTO를 도입하여 모든 REST API 응답을 표준화
Swagger(OpenAPI)
springdoc-openapi-ui 의존성 추가
/swagger-ui/index.html에서 API 문서 및 테스트 가능
테스트
EntityIntegrationTest: 엔티티-DB 매핑 통합 테스트
프론트 연동 예시
fetch/JS 기반의 REST API 연동 샘플 코드 제공
🔄 변경 영향
기존 /diary-calendar 라우팅이 DiaryController로 일원화되어 중복 매핑 오류 해결
Swagger UI를 통해 API 명세 및 테스트가 웹에서 바로 가능
프론트엔드에서 REST API를 쉽게 연동할 수 있도록 응답 포맷 및 예시 제공
🙏 리뷰어에게 하고 싶은 말
ERD 기반으로 백엔드 구조를 설계하고, 실무에서 바로 활용 가능한 API/응답 포맷/문서화까지 신경 썼습니다.
추가로 필요한 기능, API, 문서화, 테스트 등 요청사항이 있으면 언제든 말씀해 주세요!
코드 스타일, 커밋 컨벤션, 설계 방향 등 피드백 환영합니다 😊