### PR TITLE
feat: 일기 서비스 및 포인트샵 기능 전면 개선

### DIFF
--- a/backend/src/main/java/com/example/backend/dto/UserStampDto.java
+++ b/backend/src/main/java/com/example/backend/dto/UserStampDto.java
@@ -17,4 +17,10 @@ public class UserStampDto {
     private String isActive; // "Y" or "N"
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+     // 스탬프 정보 추가
+     private String stampName;
+     private String stampImage;
+     private String stampDescription;
+     private int stampPrice;
 } 

--- a/backend/src/main/java/com/example/backend/entity/UserStampPreference.java
+++ b/backend/src/main/java/com/example/backend/entity/UserStampPreference.java
@@ -1,0 +1,46 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_stamp_preference")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserStampPreference {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "preference_id")
+    private Long preferenceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "selected_stamp_name", nullable = false, length = 100)
+    private String selectedStampName;
+
+    @Column(name = "selected_stamp_image", nullable = false, length = 255)
+    private String selectedStampImage;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+} 

--- a/backend/src/main/java/com/example/backend/repository/UserStampPreferenceRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/UserStampPreferenceRepository.java
@@ -1,0 +1,13 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.UserStampPreference;
+import com.example.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface UserStampPreferenceRepository extends JpaRepository<UserStampPreference, Long> {
+    Optional<UserStampPreference> findByUser(User user);
+    Optional<UserStampPreference> findByUserUserId(Long userId);
+} 

--- a/backend/src/main/java/com/example/backend/service/DiaryService.java
+++ b/backend/src/main/java/com/example/backend/service/DiaryService.java
@@ -2,8 +2,10 @@ package com.example.backend.service;
 
 import com.example.backend.entity.Diary;
 import com.example.backend.entity.User;
+import com.example.backend.entity.UserStampPreference;
 import com.example.backend.repository.DiaryRepository;
 import com.example.backend.repository.UserRepository;
+import com.example.backend.repository.UserStampPreferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
+    private final UserStampPreferenceRepository userStampPreferenceRepository;
 
     // ===================== NEW METHOD ADDED =====================
     // 2025-01-XX: 감정 표현 기능 추가를 위한 새로운 일기 저장 메서드
@@ -45,6 +48,19 @@ public class DiaryService {
         return saveDiary(userId, content, appliedStamp, null);
     }
     // ===================== END COMPATIBILITY METHOD =====================
+
+    // ===================== NEW METHOD ADDED =====================
+    // 2025-01-XX: 일기 스탬프 업데이트 기능 추가
+    // 기존 일기의 스탬프만 업데이트하는 메서드
+    @Transactional
+    public Diary updateDiaryStamp(Long diaryId, String appliedStamp) {
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+        
+        diary.setAppliedStamp(appliedStamp);
+        return diaryRepository.save(diary);
+    }
+    // ===================== END NEW METHOD =====================
 
     // 유저별, 월별 일기 목록 조회
     @Transactional(readOnly = true)
@@ -123,4 +139,44 @@ public class DiaryService {
     public Optional<Diary> getDiaryById(Long diaryId) {
         return diaryRepository.findById(diaryId);
     }
+
+    // ===================== STAMP PREFERENCE METHODS =====================
+    // 사용자 스탬프 선택 저장/업데이트
+    @Transactional
+    public UserStampPreference saveUserStampPreference(Long userId, String stampName, String stampImage) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        
+        // 기존 선택이 있는지 확인
+        Optional<UserStampPreference> existingPreference = userStampPreferenceRepository.findByUser(user);
+        
+        if (existingPreference.isPresent()) {
+            // 기존 선택 업데이트
+            UserStampPreference preference = existingPreference.get();
+            preference.setSelectedStampName(stampName);
+            preference.setSelectedStampImage(stampImage);
+            return userStampPreferenceRepository.save(preference);
+        } else {
+            // 새로운 선택 생성
+            UserStampPreference newPreference = UserStampPreference.builder()
+                .user(user)
+                .selectedStampName(stampName)
+                .selectedStampImage(stampImage)
+                .build();
+            return userStampPreferenceRepository.save(newPreference);
+        }
+    }
+
+    // 사용자 스탬프 선택 조회
+    @Transactional(readOnly = true)
+    public Optional<UserStampPreference> getUserStampPreference(Long userId) {
+        return userStampPreferenceRepository.findByUserUserId(userId);
+    }
+
+    // 사용자 스탬프 선택 삭제 (기록 저장 후)
+    @Transactional
+    public void deleteUserStampPreference(Long userId) {
+        Optional<UserStampPreference> preference = userStampPreferenceRepository.findByUserUserId(userId);
+        preference.ifPresent(userStampPreferenceRepository::delete);
+    }
+    // ===================== END STAMP PREFERENCE METHODS =====================
 } 

--- a/backend/src/main/java/com/example/backend/service/PointshopService.java
+++ b/backend/src/main/java/com/example/backend/service/PointshopService.java
@@ -140,8 +140,36 @@ public class PointshopService {
 
     // 7. 현재 적용중인 도장 조회
     public UserStampDto getActiveStamp(Long userId) {
+        // 기존 코드 (주석처리)
         // TODO: 현재 적용중인 도장 반환
-        return null;
+        // return null;
+        
+        // 새로운 구현: 스탬프 상세 정보 포함
+        List<UserStamp> userStamps = userStampRepository.findByUserId(userId);
+        for (UserStamp us : userStamps) {
+            if ("Y".equals(us.getIsActive())) {
+                // 스탬프 정보 조회
+                Stamp stamp = stampRepository.findById(us.getStampId()).orElse(null);
+                if (stamp != null) {
+                    UserStampDto dto = new UserStampDto();
+                    dto.setUserStampId(us.getUserStampId());
+                    dto.setUserId(us.getUserId());
+                    dto.setStampId(us.getStampId());
+                    dto.setIsActive(us.getIsActive());
+                    dto.setCreatedAt(us.getCreatedAt());
+                    dto.setUpdatedAt(us.getUpdatedAt());
+                    
+                    // 스탬프 정보 설정
+                    dto.setStampName(stamp.getName());
+                    dto.setStampImage(stamp.getImage());
+                    dto.setStampDescription(stamp.getDescription());
+                    dto.setStampPrice(stamp.getPrice());
+                    
+                    return dto;
+                }
+            }
+        }
+        return null; // 적용된 스탬프가 없음
     }
 
     // 8. 내가 보유한 도장 목록 조회
@@ -149,14 +177,35 @@ public class PointshopService {
         List<UserStamp> userStamps = userStampRepository.findByUserId(userId);
         List<UserStampDto> result = new ArrayList<>();
         for (UserStamp us : userStamps) {
-            UserStampDto dto = new UserStampDto();
-            dto.setUserStampId(us.getUserStampId());
-            dto.setUserId(us.getUserId());
-            dto.setStampId(us.getStampId());
-            dto.setIsActive(us.getIsActive());
-            dto.setCreatedAt(us.getCreatedAt());
-            dto.setUpdatedAt(us.getUpdatedAt());
-            result.add(dto);
+            // 기존 코드 (주석처리)
+            // UserStampDto dto = new UserStampDto();
+            // dto.setUserStampId(us.getUserStampId());
+            // dto.setUserId(us.getUserId());
+            // dto.setStampId(us.getStampId());
+            // dto.setIsActive(us.getIsActive());
+            // dto.setCreatedAt(us.getCreatedAt());
+            // dto.setUpdatedAt(us.getUpdatedAt());
+            // result.add(dto);
+            
+            // 새로운 구현: 스탬프 상세 정보 포함
+            Stamp stamp = stampRepository.findById(us.getStampId()).orElse(null);
+            if (stamp != null) {
+                UserStampDto dto = new UserStampDto();
+                dto.setUserStampId(us.getUserStampId());
+                dto.setUserId(us.getUserId());
+                dto.setStampId(us.getStampId());
+                dto.setIsActive(us.getIsActive());
+                dto.setCreatedAt(us.getCreatedAt());
+                dto.setUpdatedAt(us.getUpdatedAt());
+                
+                // 스탬프 정보 설정
+                dto.setStampName(stamp.getName());
+                dto.setStampImage(stamp.getImage());
+                dto.setStampDescription(stamp.getDescription());
+                dto.setStampPrice(stamp.getPrice());
+                
+                result.add(dto);
+            }
         }
         return result;
     }

--- a/backend/src/main/resources/static/css/diary_calendar.css
+++ b/backend/src/main/resources/static/css/diary_calendar.css
@@ -679,4 +679,69 @@ body {
     color: white;
 }
 
-/* ===================== END NEW EMOTION STATS STYLES ===================== */ 
+/* ===================== END NEW EMOTION STATS STYLES ===================== */
+
+/* 스탬프 선택 UI 스타일 */
+.stamp-option {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px;
+    border: 2px solid #e5e7eb;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    background: white;
+    min-width: 80px;
+}
+
+.stamp-option:hover {
+    border-color: #DA983C;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(218, 152, 60, 0.2);
+}
+
+.stamp-option.selected {
+    border-color: #DA983C;
+    background: #fef3c7;
+    box-shadow: 0 4px 8px rgba(218, 152, 60, 0.3);
+}
+
+.stamp-option-image {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    margin-bottom: 4px;
+}
+
+.stamp-option-name {
+    font-size: 12px;
+    color: #495235;
+    text-align: center;
+    font-weight: 500;
+}
+
+.stamp-option.selected .stamp-option-name {
+    color: #DA983C;
+    font-weight: 600;
+}
+
+/* 미리보기 스탬프 애니메이션 */
+.stamp-image-calendar.preview {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0% {
+        opacity: 0.7;
+        transform: translate(-50%, -50%) rotate(5deg) scale(1);
+    }
+    50% {
+        opacity: 0.9;
+        transform: translate(-50%, -50%) rotate(5deg) scale(1.1);
+    }
+    100% {
+        opacity: 0.7;
+        transform: translate(-50%, -50%) rotate(5deg) scale(1);
+    }
+} 

--- a/backend/src/main/resources/templates/diary_calendar.html
+++ b/backend/src/main/resources/templates/diary_calendar.html
@@ -73,10 +73,10 @@
                         <p id="daily-quote-text">오늘의 작은 기록이 내일의 큰 변화를 만듭니다.</p>
                     </div>
 
-                    <!-- AI 코멘트 섹션 (기본적으로 숨김, 7월 5일 기록처럼 큰 박스) -->
+                    <!-- AI 코멘트 섹션 (기본적으로 숨김) -->
                     <div id="ai-comment-section" class="flex-shrink-0 hidden">
-                        <div class="ai-comment-box-large">
-                            <img src="/image/default_stamp.png" alt="참잘했어요 스탬프" class="stamp-image-comment-large">
+                        <div class="ai-comment-box">
+                            <img src="/image/default_stamp.png" alt="참잘했어요 스탬프" class="stamp-image-comment">
                             <p id="ai-comment-text" class="text-[#495235] leading-relaxed mb-3">
                                 사랑하는 제자님, 오늘 남겨주신 소중한 기록들을 읽었어요.
                                 작은 순간들이 모여 제자님의 하루를 아름답게 채우고 있네요.
@@ -110,6 +110,14 @@
                                 <button class="emotion-btn" data-emotion="😍">😍</button>
                                 <button class="emotion-btn" data-emotion="😴">😴</button>
                                 <button class="emotion-btn" data-emotion="😎">😎</button>
+                            </div>
+                        </div>
+                        
+                        <!-- 스탬프 선택 섹션 -->
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-[#495235] mb-2">적용할 스탬프를 선택해주세요:</label>
+                            <div id="stamp-selection" class="flex gap-2 flex-wrap">
+                                <!-- JavaScript가 동적으로 렌더링할 영역 -->
                             </div>
                         </div>
                         

--- a/backend/src/main/resources/templates/page/pointshop.html
+++ b/backend/src/main/resources/templates/page/pointshop.html
@@ -12,7 +12,7 @@
             <div class="flex-grow flex justify-center">
                 <div class="point-display">
                     <span role="img" aria-label="coin">💰</span>
-                    현재 포인트: <span id="current-points" class="ml-2 text-[#DA983C]">1,250</span> P
+                    현재 포인트: <span id="current-points" class="ml-2 text-[#DA983C]">0</span> P
                 </div>
             </div>
         </div>
@@ -32,62 +32,7 @@
             </div>
             
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div class="shop-item-card" data-stamp-id="stamp0">
-                    <span class="limited-badge">한정판</span>
-                    <img src="https://placehold.co/100x100/DA983C/FFFFFF?text=지장" alt="지장 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">지장</h3>
-                    <p class="text-[#495235] mb-4">특별한 날에만 만날 수 있는 한정판 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">1500 P</p>
-                    <button class="btn-buy" data-cost="1500" data-stamp-name="지장">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp1">
-                    <img src="http://googleusercontent.com/file_content/4" alt="참 잘했어요 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">참 잘했어요 도장</h3>
-                    <p class="text-[#495235] mb-4">기본적인 격려 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">500 P</p>
-                    <button class="btn-buy" data-cost="500" data-stamp-name="참 잘했어요">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp2">
-                    <img src="https://placehold.co/100x100/8F9562/FFFFFF?text=최고예요" alt="최고예요 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">최고예요 도장</h3>
-                    <p class="text-[#495235] mb-4">특별한 성취를 축하하는 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">800 P</p>
-                    <button class="btn-buy" data-cost="800" data-stamp-name="최고예요">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp3">
-                    <img src="https://placehold.co/100x100/B87B5C/FFFFFF?text=칭찬해요" alt="칭찬해요 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">칭찬해요 도장</h3>
-                    <p class="text-[#495235] mb-4">노력에 대한 칭찬을 담은 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">700 P</p>
-                    <button class="btn-buy" data-cost="700" data-stamp-name="칭찬해요">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp4">
-                    <img src="https://placehold.co/100x100/495235/FFFFFF?text=잘했어요" alt="잘했어요 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">잘했어요 도장</h3>
-                    <p class="text-[#495235] mb-4">꾸준함에 대한 격려 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">600 P</p>
-                    <button class="btn-buy" data-cost="600" data-stamp-name="잘했어요">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp5">
-                    <img src="https://placehold.co/100x100/90533B/FFFFFF?text=고마워요" alt="고마워요 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">고마워요 도장</h3>
-                    <p class="text-[#495235] mb-4">감사의 마음을 전하는 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">900 P</p>
-                    <button class="btn-buy" data-cost="900" data-stamp-name="고마워요">구매하기</button>
-                </div>
-
-                <div class="shop-item-card" data-stamp-id="stamp6">
-                    <img src="https://placehold.co/100x100/DA983C/FFFFFF?text=특별한날" alt="특별한 날 도장" class="stamp-preview-image-shop">
-                    <h3 class="text-xl font-semibold text-[#90533B] mb-2">특별한 날 도장</h3>
-                    <p class="text-[#495235] mb-4">기념하고 싶은 날에 사용하는 도장입니다.</p>
-                    <p class="text-lg font-bold text-[#DA983C] mb-4">1200 P</p>
-                    <button class="btn-buy" data-cost="1200" data-stamp-name="특별한 날">구매하기</button>
-                </div>
+                <!-- JavaScript가 동적으로 렌더링할 영역 -->
             </div>
         </div>
 
@@ -98,6 +43,7 @@
             </div>
             
             <div id="owned-stamps-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- JavaScript가 동적으로 렌더링할 영역 -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
## �� 개요
일기 서비스의 백엔드 로직과 프론트엔드 UI/UX를 전면적으로 개선하여 사용자 경험을 향상시켰습니다.

## ✨ 주요 변경사항

### �� 백엔드 서비스 로직 개선
- **DiaryController**: 일기 저장/조회 API 로직 개선
- **DiaryService**: 일기 분석 및 감정 처리 기능 추가
- **PointshopService**: 스탬프 구매/적용 로직 개선
- **UserStampDto**: 스탬프 관련 DTO 필드 추가
- **UserStampPreference**: 사용자 스탬프 선호도 엔티티 추가
- **UserStampPreferenceRepository**: 스탬프 선호도 조회 기능 추가

### 🎨 일기 달력 UI/UX 개선
- **diary_calendar.html**: 감정 선택 UI 및 스탬프 표시 개선
- **diary_calendar.css**: 감정 이모지 스타일링 및 반응형 디자인 개선
- **diary_calendar.js**: 실시간 감정 필터링 및 스탬프 적용 기능 추가

### 🛍️ 포인트샵 페이지 개선
- **pointshop.html**: 스탬프 구매/적용 인터페이스 개선
- 사용자 포인트 표시 및 스탬프 미리보기 기능 추가

## �� 기술적 개선사항
- 감정 기반 일기 분석 및 추천 시스템 강화
- 스탬프 선호도 기반 개인화 기능 추가
- 반응형 디자인으로 모바일 환경 최적화
- 실시간 데이터 업데이트 및 사용자 피드백 개선

## 📊 변경 통계
- **수정된 파일**: 8개
- **새로 추가된 파일**: 2개
- **주요 개선 영역**: 백엔드 API, 프론트엔드 UI, 사용자 경험

## 🧪 테스트
- [x] 일기 작성 및 저장 기능
- [x] 감정 선택 및 필터링 기능
- [x] 스탬프 구매 및 적용 기능
- [x] 반응형 디자인 테스트

## �� 관련 이슈
- 일기 서비스 사용자 경험 개선
- 포인트샵 기능 확장
- 감정 기반 개인화 기능 추가