### PR TITLE
refactor: 스탬프 이미지 경로 수정 및 코드 정리

### DIFF
--- a/backend/src/main/java/com/example/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/example/backend/service/MyPageService.java
@@ -81,7 +81,7 @@ public class MyPageService {
         }
         java.time.LocalDate yesterday = java.time.LocalDate.now().minusDays(1);
         int streak = 0;
-        for (com.example.backend.entity.Diary diary : diaries) {
+        for (Diary diary : diaries) {
             java.time.LocalDate diaryDate = diary.getCreatedAt().toLocalDate();
             if (diaryDate.equals(yesterday.minusDays(streak))) {
                 streak++;

--- a/backend/src/main/resources/templates/page/myPage.html
+++ b/backend/src/main/resources/templates/page/myPage.html
@@ -46,7 +46,7 @@
                 <div class="info-item flex-col items-start">
                     <span class="info-label mb-2">최근 AI 코멘트</span>
                     <div class="flex items-center text-sm text-[#495235] bg-[#F4DDB8] p-3 rounded-lg border border-[#B87B5C] w-full">
-                        <img th:src="@{/image/{img}(img=${summary.recentStampImage})}" alt="참 잘했어요 스탬프" class="stamp-image-preview mr-3">
+                        <img th:src="@{/{img}(img=${summary.recentStampImage})}" alt="참 잘했어요 스탬프" class="stamp-image-preview mr-3">
                         <span th:text="${summary.recentAiComment}">제자님, 오늘도 하루를 잘 기록했네요! 작은 노력이 큰 변화를 만든답니다.</span>
                     </div>
                 </div>


### PR DESCRIPTION
## ✅ PR 개요

- 마이페이지에서 스탬프 이미지가 표시되지 않는 문제 해결
- 코드 가독성 향상을 위한 추가 리팩토링

## 🔍 주요 리팩토링 내용

- **myPage.html**: 스탬프 이미지 경로 수정
  - `<img th:src="@{/{img}(img=${summary.recentStampImage})}"` 경로에서 불필요한 `/image` 부분 제거
  - 이미지가 정상적으로 표시되도록 경로 구조 개선

- **MyPageService.java**: 코드 가독성 개선
  - `com.example.backend.entity.Diary` → `Diary`로 변경
  - 이미 import 문에서 Diary 클래스를 import했으므로 전체 경로 참조 제거

## 🚫 동작 변화 여부

- [x] 기존 기능에 영향 없음
  - 스탬프 이미지가 정상적으로 표시되도록 수정
  - Diary 클래스 참조 방식만 변경하고 동일한 클래스 사용

## 🙏 리뷰어에게 하고 싶은 말

마이페이지에서 스탬프 이미지가 표시되지 않던 문제를 해결했습니다.
이미지 경로에서 불필요한 `/image` 부분을 제거하여 정상적으로 표시되도록 수정했고,
추가로 코드 가독성 향상을 위한 작은 리팩토링도 함께 진행했습니다.
이미지 표시가 정상적으로 되는지 확인 부탁드립니다!