### PR TITLE
fix: 활성 스탬프 없을 때 기본 스탬프 이미지 경로 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/service/PointshopService.java
+++ b/backend/src/main/java/com/example/backend/service/PointshopService.java
@@ -257,7 +257,7 @@ public class PointshopService {
         
         // 기본 스탬프 정보 설정
         defaultDto.setStampName("기본 스탬프");
-        defaultDto.setStampImage("default_stamp.png");
+        defaultDto.setStampImage("image/default_stamp.png");
         defaultDto.setStampDescription("기본 스탬프입니다.");
         defaultDto.setStampPrice(0);
         


### PR DESCRIPTION
## ✅ PR 개요

- 활성 스탬프가 없을 때 기본 스탬프 이미지가 표시되지 않는 버그를 수정했습니다.
- 정적 리소스 경로가 올바르지 않아 이미지 로딩에 실패하던 문제를 해결했습니다.

## 🔗 관련 이슈

- Resolved: #

## 🛠️ 수정 내용

- `PointshopService.java`에서 기본 스탬프 이미지 경로를 `image/default_stamp.png`로 수정
- Spring Boot의 정적 리소스 폴더 구조(`src/main/resources/static/`)에 맞게 경로 설정
- 기본 스탬프 정보 설정 부분에서 이미지 경로 추가

## ✅ 재현 방법 / 테스트 결과

- **재현 방법**: 활성 스탬프가 없는 사용자로 로그인하여 포인트샵 페이지 접속
- **테스트 결과**: 기본 스탬프 이미지가 정상적으로 표시됨을 확인
- **추가 테스트**: 다른 스탬프 이미지들도 정상적으로 표시되는지 확인 완료

## 🙏 리뷰어에게 하고 싶은 말

- 정적 리소스 경로 설정이 올바른지 확인 부탁드립니다.
- 다른 페이지에서도 이미지 경로 관련 문제가 없는지 함께 검토해 주시면 감사하겠습니다.